### PR TITLE
Solves comment interference

### DIFF
--- a/srefactor.el
+++ b/srefactor.el
@@ -793,6 +793,8 @@ BUFFER is the destination buffer from file user selects from contextual menu."
 (defun srefactor--insert-function (func-tag type)
   "Insert function implementations for FUNC-TAG at point, a tag that is a function.
 `type' is the operation to be done, not the type of the tag."
+  (newline)
+  (left-char)
   (if srefactor-use-srecode-p
       ;; Try using SRecode as the mechanism for inserting a tag.
       (srefactor--insert-with-srecode func-tag)


### PR DESCRIPTION
--- foo.hpp
```c++
namespace one {
namespace two {
class Test {
    Test();
    ~Tes|t(); // cursor at |
}; }}
```
--- foo.cpp
```c++
namespace one {
namespace two {
Test::Test() {
    
}
// Comment
}}
```

M-x srefactor-refactor-at-point

--- foo.cpp
```c++
namespace one {
namespace two {
Test::Test() {
    
}

Test::~Test()// Comment {

}
}}
```