### PR TITLE
[Fix #38] Properly generate functions with `const char *` parameter.

### DIFF
--- a/srefactor.el
+++ b/srefactor.el
@@ -824,7 +824,7 @@ BUFFER is the destination buffer from file user selects from contextual menu."
           (insert (srefactor--tag-templates-declaration-string parent)))
         (insert (srefactor--tag-function-string func-tag))
 
-        ;; insert const modifer for method
+        ;; insert const modifier for method
         (when (semantic-tag-get-attribute func-tag :methodconst-flag)
           (insert " const"))
 
@@ -1321,18 +1321,20 @@ complicated language construct, Semantic cannot retrieve it."
                                           ref-string)
                                          (t "")))))
      (t
-      (if (listp tag-type)
-          (concat (when const-p
-                    "const ")
-                  (when (srefactor--tag-struct-p tag)
-                    "struct ")
-                  (car tag-type)
-                  (cond
-                   (ref-level
-                    ref-string)
-                   (ptr-level
-                    ptr-string)))
-        tag-type)))))
+      (concat (when const-p
+                "const ")
+              (if (not (listp tag-type))
+                tag-type
+                (when (srefactor--tag-struct-p tag)
+                  "struct ")
+                (car tag-type))
+              (cond
+               (ref-level
+                ref-string)
+               (ptr-level
+                ptr-string)
+               (t
+                "")))))))
 
 (defun srefactor--tag-type-string-inner-template-list (tmpl-spec-list)
   (mapconcat (lambda (tmpl)


### PR DESCRIPTION
Hi,

Please note that this will make return type of the generated implementation incorrect,
for example, a method with a reference type of parameter:

    // -*- mode: c++; -*-
    class FooBar
    {
    public:

        // FooBar();
        // virtual ~FooBar();

        int foo (const char *name, int &type, char &bar);
    };

will generate:

    int& FooBar::foo(const char* name, int& type, char& bar) {
        return 0;
    }

This is caused by the additional check in `srefactor--tag-reference`, when fetching the return type:

    (defun srefactor--tag-function-string (tag)
      "Return a complete string representation of a TAG that is a function."
      (let ((return-type (srefactor--tag-type-string tag))
    ...
    
In this circumstance, the `tag` is the method prototype, which makes `srefactor--tag-reference`
take `&` in parameter list into account.

I have no idea how to properly fix this, maybe we can just remove the additional check?
so that it works for simple cases and keep code simple.
