### PR TITLE
Bugfix: error when creating menu.

### DIFF
--- a/srefactor-ui.el
+++ b/srefactor-ui.el
@@ -226,7 +226,7 @@ when the corresponding MENU-ITEM is selected."
                                  100)
                               (/ (* (frame-height) 10)
                                  100))
-        (when (and (fboundp 'evil-mode)
+        (when (and (boundp 'evil-mode)
                    evil-mode)
           (evil-local-mode)))
     (error (srefactor-ui--clean-up-menu-window)


### PR DESCRIPTION
`evil-mode' is a autoload function, but if evil mode not loaded,
`srefactor-refactor-at-point' could error out.