### PR TITLE
fix number of arguments for `projectile-get-other-files'

### DIFF
--- a/srefactor.el
+++ b/srefactor.el
@@ -361,7 +361,6 @@ FILE-OPTION is a file destination associated with OPERATION."
           (condition-case nil
               (progn
                 (setq other-files (projectile-get-other-files (buffer-file-name)
-                                                              (projectile-current-project-files)
                                                               nil))
                 (setq l (length other-files))
                 (setq file (concat (projectile-project-root)


### PR DESCRIPTION
projectile-get-other-files only takes two arguments.